### PR TITLE
Fix: Typo on multipart form content type and adds URI field to StringFormat

### DIFF
--- a/src/openapi_parser/enumeration.py
+++ b/src/openapi_parser/enumeration.py
@@ -33,6 +33,7 @@ class StringFormat(Enum):
     PASSWORD = 'password'
     UUID = 'uuid'
     EMAIL = 'email'
+    URI = 'uri'
 
 
 @unique
@@ -67,7 +68,7 @@ class ContentType(Enum):
     JSON = 'application/json'
     XML = 'application/xml'
     FORM = 'application/x-www-form-urlencoded'
-    MULTIPART_FORM = 'multipart_form/form-data'
+    MULTIPART_FORM = 'multipart/form-data'
     PLAIN_TEXT = 'text/plain'
     HTML = 'text/html'
     PDF = 'application/pdf'

--- a/tests/data/swagger.yml
+++ b/tests/data/swagger.yml
@@ -248,6 +248,7 @@ components:
         - required:
             - login
             - email
+            - avatar
         - properties:
             login:
               type: string
@@ -258,3 +259,8 @@ components:
               format: email
               example: 'user@mail.com'
               description: 'User E-mail address'
+            avatar:
+              type: string
+              format : uri
+              example: 'https://github.com/manchenkoff/openapi3-parser'
+              description: 'User Avatar URL'

--- a/tests/openapi_fixture.py
+++ b/tests/openapi_fixture.py
@@ -2,7 +2,7 @@ from openapi_parser.specification import *
 
 schema_user = Object(
     type=DataType.OBJECT,
-    required=["uuid", "login", "email"],
+    required=["uuid", "login", "email", "avatar"],
     properties=[
         Property(
             name="uuid",
@@ -28,6 +28,15 @@ schema_user = Object(
                 description="User E-mail address",
                 example="user@mail.com",
                 format=StringFormat.EMAIL,
+            )
+        ),
+        Property(
+            name="avatar",
+            schema=String(
+                type=DataType.STRING,
+                description="User Avatar URL",
+                example="https://github.com/manchenkoff/openapi3-parser",
+                format=StringFormat.URI,
             )
         ),
     ],
@@ -222,7 +231,7 @@ def create_specification() -> Specification:
         ),
         "User": Object(
             type=DataType.OBJECT,
-            required=["uuid", "login", "email"],
+            required=["uuid", "login", "email", "avatar"],
             properties=[
                 Property(
                     name="uuid",
@@ -248,6 +257,15 @@ def create_specification() -> Specification:
                         format=StringFormat.EMAIL,
                         example="user@mail.com",
                         description="User E-mail address",
+                    )
+                ),
+                Property(
+                    name="avatar",
+                    schema=String(
+                        type=DataType.STRING,
+                        description="User Avatar URL",
+                        example="https://github.com/manchenkoff/openapi3-parser",
+                        format=StringFormat.URI,
                     )
                 ),
             ],

--- a/tests/test_enumeration.py
+++ b/tests/test_enumeration.py
@@ -62,6 +62,7 @@ string_format_provider = (
     ("password", StringFormat.PASSWORD),
     ("uuid", StringFormat.UUID),
     ("email", StringFormat.EMAIL),
+    ("uri", StringFormat.URI),
 )
 
 
@@ -136,7 +137,7 @@ media_type_provider = (
     ("application/json", ContentType.JSON),
     ("application/xml", ContentType.XML),
     ("application/x-www-form-urlencoded", ContentType.FORM),
-    ("multipart_form/form-data", ContentType.MULTIPART_FORM),
+    ("multipart/form-data", ContentType.MULTIPART_FORM),
     ("text/plain", ContentType.PLAIN_TEXT),
     ("text/html", ContentType.HTML),
     ("application/pdf", ContentType.PDF),


### PR DESCRIPTION
`multipart_form/form-data` was a typo for `multipart/form-data`; fixed.
Adds optional `URI` format type to StringFormat and updates the tests to cover this.