### PR TITLE
Implement skipping strict enums during parsing

### DIFF
--- a/src/openapi_parser/builders/content.py
+++ b/src/openapi_parser/builders/content.py
@@ -1,17 +1,23 @@
 import logging
+from typing import Type, Union
 
 from . import SchemaFactory
 from ..enumeration import ContentType
 from ..specification import Content
+from ..loose_types import LooseContentType
 
 logger = logging.getLogger(__name__)
+
+ContentTypeType = Union[Type[ContentType], Type[LooseContentType]]
 
 
 class ContentBuilder:
     schema_factory: SchemaFactory
+    strict_enum: bool
 
-    def __init__(self, schema_factory: SchemaFactory) -> None:
+    def __init__(self, schema_factory: SchemaFactory, strict_enum: bool = True) -> None:
         self.schema_factory = schema_factory
+        self.strict_enum = strict_enum
 
     def build_list(self, data: dict) -> list[Content]:
         return [
@@ -22,8 +28,8 @@ class ContentBuilder:
 
     def _create_content(self, content_type: str, content_value: dict) -> Content:
         logger.debug(f"Content building [type={content_type}]")
-
+        ContentTypeCls: ContentTypeType = ContentType if self.strict_enum else LooseContentType
         return Content(
-            type=ContentType(content_type),
+            type=ContentTypeCls(content_type),
             schema=self.schema_factory.create(content_value)
         )

--- a/src/openapi_parser/loose_types.py
+++ b/src/openapi_parser/loose_types.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class LooseEnum:
+    value: str
+
+
+LooseContentType = LooseEnum
+LooseIntegerFormat = LooseEnum
+LooseNumberFormat = LooseEnum
+LooseStringFormat = LooseEnum

--- a/src/openapi_parser/parser.py
+++ b/src/openapi_parser/parser.py
@@ -78,15 +78,15 @@ class Parser:
         return Specification(**attrs)
 
 
-def _create_parser() -> Parser:
+def _create_parser(strict_enum: bool = True) -> Parser:
     logger.info("Initializing parser")
 
     info_builder = InfoBuilder()
     server_builder = ServerBuilder()
     external_doc_builder = ExternalDocBuilder()
     tag_builder = TagBuilder(external_doc_builder)
-    schema_factory = SchemaFactory()
-    content_builder = ContentBuilder(schema_factory)
+    schema_factory = SchemaFactory(strict_enum=strict_enum)
+    content_builder = ContentBuilder(schema_factory, strict_enum=strict_enum)
     header_builder = HeaderBuilder(schema_factory)
     parameter_builder = ParameterBuilder(schema_factory)
     schemas_builder = SchemasBuilder(schema_factory)
@@ -109,15 +109,18 @@ def _create_parser() -> Parser:
                   schemas_builder)
 
 
-def parse(uri: str) -> Specification:
+def parse(uri: str, strict_enum: bool = True) -> Specification:
     """Parse specification document by URL or filepath
 
     Args:
         uri (str): Path or URL to OpenAPI file
+        strict_enum (bool): Validate content types and string formats against the
+          enums defined in openapi-parser. Note that the OpenAPI specification allows
+          for custom values in these properties.
     """
     resolver = OpenAPIResolver(uri)
     specification = resolver.resolve()
 
-    parser = _create_parser()
+    parser = _create_parser(strict_enum=strict_enum)
 
     return parser.load_specification(specification)

--- a/src/openapi_parser/specification.py
+++ b/src/openapi_parser/specification.py
@@ -1,7 +1,13 @@
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from .enumeration import *
+from .loose_types import (
+    LooseContentType,
+    LooseIntegerFormat,
+    LooseNumberFormat,
+    LooseStringFormat,
+)
 
 
 @dataclass
@@ -80,7 +86,7 @@ class Integer(Schema):
     exclusive_maximum: Optional[int] = None
     minimum: Optional[int] = None
     exclusive_minimum: Optional[int] = None
-    format: Optional[IntegerFormat] = None
+    format: Optional[Union[IntegerFormat, LooseIntegerFormat]] = None
 
 
 @dataclass
@@ -90,7 +96,7 @@ class Number(Schema):
     exclusive_maximum: Optional[float] = None
     minimum: Optional[float] = None
     exclusive_minimum: Optional[float] = None
-    format: Optional[NumberFormat] = None
+    format: Optional[Union[NumberFormat, LooseNumberFormat]] = None
 
 
 @dataclass
@@ -98,7 +104,7 @@ class String(Schema):
     max_length: Optional[int] = None
     min_length: Optional[int] = None
     pattern: Optional[str] = None
-    format: Optional[StringFormat] = None
+    format: Optional[Union[StringFormat, LooseStringFormat]] = None
 
 
 @dataclass
@@ -158,7 +164,7 @@ class Parameter:
 
 @dataclass
 class Content:
-    type: ContentType
+    type: Union[ContentType, LooseContentType]
     schema: Schema
     # example: Optional[Any]  # TODO
     # examples: list[Any] = field(default_factory=list)  # TODO

--- a/tests/data/non-strict.yml
+++ b/tests/data/non-strict.yml
@@ -1,0 +1,35 @@
+---
+
+# minimalistic schema with non-standard but valid spec items:
+# - custom content-types
+# - 'custom' string type formats
+#
+# See issue #40 for more context.
+openapi: 3.0.3
+
+info:
+  title: 'Non-strict enum schema'
+  version: 1.0.0
+
+paths:
+  /sample-endpoint-1:
+    get:
+      responses:
+        200:
+          description: 'OK'
+          content:
+            application/hal+json:
+              schema:
+                type: object
+                properties:
+                  expectedDeliveryDuration:
+                    type: string
+                    format: duration
+
+        400:
+          description: 'Bad Request'
+          content:
+            application/problem+json:
+              schema:
+                type: object
+                properties: {}

--- a/tests/test_parser_options.py
+++ b/tests/test_parser_options.py
@@ -1,0 +1,27 @@
+import pytest
+
+from openapi_parser import parse
+from openapi_parser.errors import ParserError
+
+TEST_SCHEMA = './tests/data/non-strict.yml'
+
+
+def test_default_strict_enum_errors() -> None:
+    with pytest.raises(ParserError):
+        parse(TEST_SCHEMA)
+
+
+def test_with_non_strict_enum_succeeds() -> None:
+    specification = parse(TEST_SCHEMA, strict_enum=False)
+
+    response_200, response_400 = specification.paths[0].operations[0].responses
+
+    response_hal_json = response_200.content[0]
+    assert response_hal_json.type.value == "application/hal+json"
+    duration_property = response_hal_json.schema.properties[0]
+    assert duration_property.name == "expectedDeliveryDuration"
+    assert duration_property.schema.type.value == "string"
+    assert duration_property.schema.format.value == "duration"
+
+    response_problem_json = response_400.content[0]
+    assert response_problem_json.type.value == "application/problem+json"


### PR DESCRIPTION
Fixes #40

Added the `strict_enum` flag to the parse function, which is forwarded to the underlying builders. The default value is `True` to keep the current default behaviour.

The `Loose<EnumType>` classes mimick the `Enum` API through the `value` attribute, so downstream users don't need to check the type of `Schema.format` or `Content.type`.