### PR TITLE
Fix: Missing import for except block criteria.

### DIFF
--- a/src/openapi_parser/resolver.py
+++ b/src/openapi_parser/resolver.py
@@ -1,6 +1,7 @@
 import logging
 
 import prance
+import prance.util.formats
 
 from .errors import ParserError
 


### PR DESCRIPTION
Missing import statement causing another exception to be raised when the second except clause was caught (reproducible with an open API schema URL that would return a `404 Not Found` error), due to missing imports.