### PR TITLE
Loosen OpenAPI spec validator version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
     ],
     install_requires=[
         "prance>=0.20.2",
-        "openapi-spec-validator>=0.2.9,<0.5.0",
+        "openapi-spec-validator",
     ],
 )


### PR DESCRIPTION
It seems like the repository's Pipfile uses openapi-spec-validator 0.5.5, but the install requires has <0.5.0