### PR TITLE
Add py.typed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     version=openapi_parser.__version__,
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
+    package_data={"openapi_parser": ["py.typed"]},
     license="MIT",
     description=openapi_parser.__description__,
     long_description=open(description_file).read(),


### PR DESCRIPTION
From: https://peps.python.org/pep-0561/ and https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/

This basically tells mypy and pyright that the package is typed 😊

