### PR TITLE
Handle missing `type` key in schema

### DIFF
--- a/src/openapi_parser/builders/schema.py
+++ b/src/openapi_parser/builders/schema.py
@@ -47,7 +47,7 @@ def extract_attrs(data: dict, attrs_map: Dict[str, PropertyMeta]) -> Dict[str, A
         if data.get(name) is not None
     }
 
-    attrs['type'] = DataType(attrs['type'])
+    attrs['type'] = DataType(attrs.get('type', DataType.ANY_OF))
 
     attrs.update(extract_typed_props(data, attrs_map))
 
@@ -111,7 +111,7 @@ class SchemaFactory:
         try:
             schema_type = data['type']
         except KeyError:
-            raise ParserError("Schema does not contain 'type' property")
+            schema_type = DataType.ANY_OF
 
         try:
             data_type = DataType(schema_type)

--- a/src/openapi_parser/builders/schema.py
+++ b/src/openapi_parser/builders/schema.py
@@ -47,7 +47,7 @@ def extract_attrs(data: dict, attrs_map: Dict[str, PropertyMeta]) -> Dict[str, A
         if data.get(name) is not None
     }
 
-    attrs['type'] = DataType(attrs.get('type', DataType.ANY_OF))
+    attrs['type'] = DataType(attrs['type'])
 
     attrs.update(extract_typed_props(data, attrs_map))
 
@@ -111,6 +111,7 @@ class SchemaFactory:
         try:
             schema_type = data['type']
         except KeyError:
+            logger.warning(msg="Implicit type assignment: schema does not contain 'type' property")
             schema_type = DataType.ANY_OF
 
         try:
@@ -224,4 +225,18 @@ class SchemaFactory:
             "schemas": PropertyMeta(name="anyOf", cast=create_inner_schemas)
         }
 
-        return AnyOf(**extract_attrs(data, attrs_map))
+        if "type" in data:
+            return AnyOf(**extract_attrs(data, attrs_map))
+
+        possible_implicit_types = (
+            DataType.INTEGER, DataType.NUMBER, DataType.STRING, DataType.BOOLEAN, DataType.ARRAY, DataType.OBJECT
+        )
+        schemas = [
+            schema_factory({**data, **{"type": data_type}}) 
+            for data_type, schema_factory in self._builders.items()
+            if data_type in possible_implicit_types
+        ]
+
+        return AnyOf(type=DataType.ANY_OF, schemas=schemas)
+
+

--- a/tests/builders/schema/test_anyof.py
+++ b/tests/builders/schema/test_anyof.py
@@ -2,7 +2,7 @@ import pytest
 
 from openapi_parser.builders.schema import SchemaFactory
 from openapi_parser.enumeration import IntegerFormat
-from openapi_parser.specification import DataType, Discriminator, Integer, AnyOf, String, StringFormat
+from openapi_parser.specification import DataType, Integer, AnyOf, String, StringFormat, Number, Boolean, Array, Object
 
 data_provider = (
     (
@@ -38,6 +38,16 @@ data_provider = (
             ]
         )
     ),
+    (
+        {
+            "description": "Can be any value - string, number, boolean, array or object."
+        },
+        AnyOf(
+            type=DataType.ANY_OF,
+            description="Can be any value - string, number, boolean, array or object.",
+            schemas=[]
+        )
+    )
 )
 
 

--- a/tests/builders/schema/test_anyof.py
+++ b/tests/builders/schema/test_anyof.py
@@ -2,7 +2,10 @@ import pytest
 
 from openapi_parser.builders.schema import SchemaFactory
 from openapi_parser.enumeration import IntegerFormat
-from openapi_parser.specification import DataType, Integer, AnyOf, String, StringFormat, Number, Boolean, Array, Object
+from openapi_parser.specification import DataType, Integer, AnyOf, String, StringFormat, Array, Number, Boolean, Object, Property
+
+string_schema = String(type=DataType.STRING)
+number_schema = Number(type=DataType.NUMBER)
 
 data_provider = (
     (
@@ -40,12 +43,59 @@ data_provider = (
     ),
     (
         {
-            "description": "Can be any value - string, number, boolean, array or object."
+            "description": "Can be any type - string, number, integer, boolean, object and array"
         },
         AnyOf(
             type=DataType.ANY_OF,
-            description="Can be any value - string, number, boolean, array or object.",
-            schemas=[]
+            schemas=[
+                Integer(type=DataType.INTEGER, description="Can be any type - string, number, integer, boolean, object and array",),
+                Number(type=DataType.NUMBER, description="Can be any type - string, number, integer, boolean, object and array",),
+                String(type=DataType.STRING, description="Can be any type - string, number, integer, boolean, object and array",),
+                Boolean(type=DataType.BOOLEAN, description="Can be any type - string, number, integer, boolean, object and array",),
+                Array(type=DataType.ARRAY, description="Can be any type - string, number, integer, boolean, object and array",),
+                Object(type=DataType.OBJECT, properties=[], description="Can be any type - string, number, integer, boolean, object and array",)
+            ]
+        )
+    ),
+    (
+        {
+            "description": "Array with implicit type.",
+            "items": {"type": "string"}
+        },
+        AnyOf(
+            type=DataType.ANY_OF,
+            schemas=[
+                Integer(type=DataType.INTEGER, description="Array with implicit type."),
+                Number(type=DataType.NUMBER, description="Array with implicit type."),
+                String(type=DataType.STRING, description="Array with implicit type."),
+                Boolean(type=DataType.BOOLEAN, description="Array with implicit type."),
+                Array(type=DataType.ARRAY, items=string_schema, description="Array with implicit type."),
+                Object(type=DataType.OBJECT, properties=[], description="Array with implicit type."),
+            ]
+        )
+    ),
+    (
+        {
+            "description": "Object with implicit type.",
+            "properties": {
+                "property1": {"type": "string"},
+                "property2": {"type": "number"}
+            }
+        },
+        AnyOf(
+            type=DataType.ANY_OF,
+            schemas=[
+                Integer(type=DataType.INTEGER, description="Object with implicit type."),
+                Number(type=DataType.NUMBER, description="Object with implicit type."),
+                String(type=DataType.STRING, description="Object with implicit type."),
+                Boolean(type=DataType.BOOLEAN, description="Object with implicit type."),
+                Array(type=DataType.ARRAY, description="Object with implicit type."),
+                Object(
+                    type=DataType.OBJECT,
+                    properties=[Property("property1", string_schema), Property("property2", number_schema)],
+                    description="Object with implicit type."
+                ),
+            ]
         )
     )
 )


### PR DESCRIPTION
Fixes #61

I'm not sure if the approach of setting `schema_type = DataType.ANY_OF` is correct, perhaps this should become an explicit schema with all possible types?