### PR TITLE
Add support for application/problem+json content type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# VS Code
+.history
+.vscode

--- a/src/openapi_parser/enumeration.py
+++ b/src/openapi_parser/enumeration.py
@@ -99,6 +99,7 @@ class ContentType(Enum):
     JSON = 'application/json'
     JSON_TEXT = 'text/json'
     JSON_ANY = 'application/*+json'
+    JSON_PROBLEM = 'application/problem+json'
     XML = 'application/xml'
     FORM = 'application/x-www-form-urlencoded'
     MULTIPART_FORM = 'multipart/form-data'

--- a/tests/test_enumeration.py
+++ b/tests/test_enumeration.py
@@ -140,6 +140,7 @@ def test_parameter_location_error() -> None:
 media_type_provider = (
     ("application/json", ContentType.JSON),
     ("application/*+json", ContentType.JSON_ANY),
+    ("application/problem+json", ContentType.JSON_PROBLEM),
     ("text/json", ContentType.JSON_TEXT),
     ("application/xml", ContentType.XML),
     ("application/x-www-form-urlencoded", ContentType.FORM),


### PR DESCRIPTION
This addition enables seamless handling of error responses conforming to RFC 7807.