### PR TITLE
fix: update openapi-spec-validator version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     ],
     install_requires=[
         "prance>=0.20.2",
-        "openapi-spec-validator==0.6.0",
+        "openapi-spec-validator>=0.7.1",
     ],
 )


### PR DESCRIPTION
The Pipfile indicates that `openapi-spec-validator` version 0.7.1 is required, however the setup.py file specified a dependency of exactly 0.6.0. When pulling this project down via pip, this would cause the 0.6.0 version to be pulled and then the openapi3 parse would error because of  a missing `validator` function that was introduced in the later version of the `openapi-spec-validator`.

The workaround for this is to manually install `openapi-spec-validator` using `pip install openapi-spec-validator==0.7.1 --no-deps`.

This fix should allow the correct version to be pulled on future releases of the `openapi3-parser` library.